### PR TITLE
feat: exclude stopped processes from is_vim check

### DIFF
--- a/is_vim.sh
+++ b/is_vim.sh
@@ -8,8 +8,11 @@ pane_pid=$(tmux display -p "#{pane_pid}")
 
 # Retrieve all descendant processes of the tmux pane's shell by iterating through the process tree.
 # This includes child processes and their descendants recursively.
-descendants=$(ps -eo pid=,ppid= | awk -v pid="$pane_pid" '{
-    pid_array[$1]=$2
+# excludes "stopped" processes as they are not considered active.
+descendants=$(ps -eo pid=,ppid=,state= | awk -v pid="$pane_pid" '{
+    if ($3 != "T") {
+        pid_array[$1]=$2
+    }
 } END {
     for (p in pid_array) {
         current_pid = p

--- a/is_vim.sh
+++ b/is_vim.sh
@@ -9,8 +9,8 @@ pane_pid=$(tmux display -p "#{pane_pid}")
 # Retrieve all descendant processes of the tmux pane's shell by iterating through the process tree.
 # This includes child processes and their descendants recursively.
 # excludes "stopped" processes as they are not considered active.
-descendants=$(ps -eo pid=,ppid=,state= | awk -v pid="$pane_pid" '{
-    if ($3 != "T") {
+descendants=$(ps -eo pid=,ppid=,stat= | awk -v pid="$pane_pid" '{
+    if ($3 !~ /^T/) {
         pid_array[$1]=$2
     }
 } END {


### PR DESCRIPTION
if a vim process has been sent to the background in bash (or other shells) via the Ctrl+Z shortcut, it still affects the is_vim check even though the process is stopped. this change causes the check to ignore those stopped processes

Ended up making this change in my own setup and figured i'd contribute it back in case it's useful 😄 tested this fully on macos, and did some basic checking on linux to make sure the stat parameter worked as expected there and it appears to.